### PR TITLE
wsus_server_core roleとAzureテストインフラの追加

### DIFF
--- a/.github/workflows/_template_azure_test.yml
+++ b/.github/workflows/_template_azure_test.yml
@@ -1,0 +1,93 @@
+name: Reusable Infrastructure Test Logic
+
+on:
+  workflow_call:  # 他のWorkflowから呼ばれる専用
+    inputs:
+      tf_working_dir:
+        required: true
+        type: string
+        description: "Path to Terraform directory"
+      ansible_playbook_path:
+        required: true
+        type: string
+        description: "Path to Ansible playbook"
+    secrets:
+      AZURE_CLIENT_ID:
+        required: true
+      AZURE_CLIENT_SECRET:
+        required: true
+      AZURE_SUBSCRIPTION_ID:
+        required: true
+      AZURE_TENANT_ID:
+        required: true
+      VM_ADMIN_PASSWORD:
+        required: true
+
+jobs:
+  integration-test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        # 受け取った引数(inputs)を使用
+        working-directory: ${{ inputs.tf_working_dir }}
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+
+      # --- 1. Terraform Setup & Apply ---
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v3
+
+      - name: Terraform Init
+        run: terraform init
+
+      - name: Terraform Apply
+        id: apply
+        run: terraform apply -auto-approve
+      
+      # 作成されたIPアドレスを取得して環境変数にセット
+      - name: Get VM IP
+        run: |
+          echo "VM_IP=$(terraform output -raw public_ip)" >> $GITHUB_ENV
+
+      # --- 2. Ansible Setup & Run ---
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install Ansible and dependencies
+        run: |
+          pip install ansible pywinrm
+      
+      # インベントリファイルを動的生成
+      - name: Create Inventory
+        run: |
+          cat <<EOF > inventory.ini
+          [windows]
+          ${{ env.VM_IP }}
+
+          [windows:vars]
+          ansible_user=azureuser
+          ansible_password=${{ secrets.VM_ADMIN_PASSWORD }}
+          ansible_connection=winrm
+          ansible_winrm_server_cert_validation=ignore
+          ansible_port=5986
+          ansible_winrm_scheme=https
+          ansible_winrm_transport=basic
+          EOF
+          # UbuntuランナーなのでM1 Mac用の暗号化無効設定は不要です
+
+      # --- 3. Ansible Playbook実行 ---     
+      # 例: Playbook実行
+      - name: Run Ansible Playbook
+        run: |
+          # inputsを参照
+          ansible-playbook -i inventory.ini ${{ inputs.ansible_playbook_path }}
+      
+      # --- 4. Cleanup (Always run) ---
+      # テストが成功しても失敗しても必ず実行して課金を止める
+      - name: Terraform Destroy
+        if: always() 
+        run: terraform destroy -auto-approve

--- a/.github/workflows/test_role_wsus_server_core.yml
+++ b/.github/workflows/test_role_wsus_server_core.yml
@@ -1,0 +1,22 @@
+name: Test Role - WSUS Server Core
+
+on:
+  workflow_dispatch:
+  # mainブランチへのプッシュで自動実行したい場合はコメントアウトを外す
+  # push:
+  #   branches: [ "main" ]
+  #   paths:
+  #     - 'roles/wsus_server_core/**'
+
+jobs:
+  call-test-workflow:
+    uses: ./.github/workflows/_template_azure_test.yml
+    with:
+      tf_working_dir: './roles/wsus_server_core/tests/azure_infra'
+      ansible_playbook_path: '../../main.yml'
+    secrets:
+      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+      AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
+      AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+      VM_ADMIN_PASSWORD: ${{ secrets.VM_ADMIN_PASSWORD }}

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ venv/
 
 # ローカルテスト用
 test/
+inventory.ini

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,0 +1,5 @@
+[defaults]
+stdout_callback = yaml
+
+[callback_default]
+result_format = yaml

--- a/inventory.ini.sample
+++ b/inventory.ini.sample
@@ -1,0 +1,12 @@
+[windows]
+# Terraform出力のIPアドレスをここに記載してください
+<IP_ADDRESS_HERE>
+
+[windows:vars]
+ansible_user=azureuser
+ansible_password=<PASSWORD_HERE>
+ansible_connection=winrm
+ansible_winrm_server_cert_validation=ignore
+ansible_port=5986
+ansible_winrm_scheme=https
+ansible_winrm_transport=basic

--- a/roles/wsus_server_core/README.md
+++ b/roles/wsus_server_core/README.md
@@ -1,0 +1,53 @@
+# Role Name: wsus_server_core
+
+Windows Server Update Services (WSUS) のインストール、WID (Windows Internal Database) の初期化、およびサービス管理を行います。
+本 Role は「Core Role」として機能し、WSUSの基盤構築を担当します。
+
+## Requirements
+
+  * Windows Server 2016 / 2019 / 2022
+  * Ansible Collection: `ansible.windows`, `community.windows`
+
+## ⚙️ Role Variables
+
+本 Role で定義されている変数は、以下の2種類に分類されます。
+
+1.  **Defaults (`defaults/main.yml`):** ユーザーがオーバーライド可能な基本設定値。
+2.  **Internal Vars (`vars/main.yml`):** 内部で使用する定数（通常は変更不要）。
+
+### 1\. User Configurable Variables (defaults/main.yml)
+
+| 変数名 | デフォルト値 | 説明 |
+| :--- | :--- | :--- |
+| `wsus_server_core_content_dir` | `'C:\WSUS'` | 更新プログラムのコンテンツを保存するローカルディレクトリ |
+| `wsus_server_core_features` | `['UpdateServices', ...]` | インストールするWSUS関連機能のリスト |
+| `wsus_server_core_service_state` | `started` | WSUSサービスの期待する状態 |
+
+### 2\. Internal Constants (vars/main.yml)
+
+| 変数名 | 設定値 | 説明 |
+| :--- | :--- | :--- |
+| `wsus_server_core_service_name` | `WsusService` | WSUS サービス名 |
+| `wsus_server_core_wsusutil_path` | `...` | `wsusutil.exe` への絶対パス |
+
+## 📖 Example Playbook
+
+### 基本的な使用法
+
+Core Role を呼び出し、WSUSをインストールします。
+
+```yaml
+- hosts: wsus_servers
+  gather_facts: no
+  roles:
+    - role: my_company.middleware.wsus_server_core
+      vars:
+        wsus_server_core_content_dir: 'D:\WSUS_Content'
+```
+
+## ✅ Quality Assurance
+
+本 Role は以下の動作を保証します。
+
+  * **冪等性:** 複数回実行しても「すでにインストール/設定済み」として扱われ、エラーにならないこと。
+  * **初期化:** `wsusutil postinstall` が実行され、指定したコンテンツディレクトリが正しく認識されること。

--- a/roles/wsus_server_core/README.md
+++ b/roles/wsus_server_core/README.md
@@ -1,11 +1,11 @@
 # Role Name: wsus_server_core
 
-Windows Server Update Services (WSUS) のインストール、WID (Windows Internal Database) の初期化、およびサービス管理を行います。
+Windows Server Update Services (WSUS) のインストール、WID (Windows Internal Database) の初期化、IIS プールの設定、および定期的なクリーンアップタスクの登録を行います。
 本 Role は「Core Role」として機能し、WSUSの基盤構築を担当します。
 
 ## Requirements
 
-  * Windows Server 2016 / 2019 / 2022
+  * Windows Server 2025
   * Ansible Collection: `ansible.windows`, `community.windows`
 
 ## ⚙️ Role Variables
@@ -22,13 +22,24 @@ Windows Server Update Services (WSUS) のインストール、WID (Windows Inter
 | `wsus_server_core_content_dir` | `'C:\WSUS'` | 更新プログラムのコンテンツを保存するローカルディレクトリ |
 | `wsus_server_core_features` | `['UpdateServices', ...]` | インストールするWSUS関連機能のリスト |
 | `wsus_server_core_service_state` | `started` | WSUSサービスの期待する状態 |
+| `wsus_server_core_service_enabled` | `true` | WSUSサービスの自動起動設定 |
 
 ### 2\. Internal Constants (vars/main.yml)
 
 | 変数名 | 設定値 | 説明 |
 | :--- | :--- | :--- |
 | `wsus_server_core_service_name` | `WsusService` | WSUS サービス名 |
+| `wsus_server_core_iis_service_name` | `W3SVC` | IIS サービス名 |
 | `wsus_server_core_wsusutil_path` | `...` | `wsusutil.exe` への絶対パス |
+
+## 📖 Main Tasks
+
+本 Role は以下のタスクを実行します。
+
+1.  **Install (`01_install.yml`)**: WSUS機能および管理ツールのインストール。
+2.  **Post Install (`02_post_install.yml`)**: `wsusutil postinstall` による初期化とサービス起動。
+3.  **Configure IIS (`03_configure_iis.yml`)**: `WsusPool` のプライベートメモリ制限を解除 (0に設定) し、クラッシュを防止。
+4.  **Schedule Cleanup (`04_schedule_cleanup.yml`)**: 「WSUS Monthly Cleanup」タスクを作成し、毎月1日に不要な更新プログラムやコンピュータの削除を実行。
 
 ## 📖 Example Playbook
 
@@ -51,3 +62,4 @@ Core Role を呼び出し、WSUSをインストールします。
 
   * **冪等性:** 複数回実行しても「すでにインストール/設定済み」として扱われ、エラーにならないこと。
   * **初期化:** `wsusutil postinstall` が実行され、指定したコンテンツディレクトリが正しく認識されること。
+  * **安定性:** IISの `WsusPool` 設定が最適化され、高負荷時の停止を防ぐ設定が行われること。

--- a/roles/wsus_server_core/defaults/main.yml
+++ b/roles/wsus_server_core/defaults/main.yml
@@ -1,0 +1,17 @@
+---
+# WSUS コンテンツの保存先ディレクトリ
+wsus_server_core_content_dir: 'C:\WSUS'
+
+# インストールするWSUSの機能コンポーネント
+# UpdateServices-WidDB: WID Database (Default)
+# UpdateServices-Services: WSUS Services
+# UpdateServices-RSAT: Management Tools
+wsus_server_core_features:
+  - UpdateServices
+  - UpdateServices-WidDB
+  - UpdateServices-Services
+  - UpdateServices-RSAT
+
+# サービスの基本状態
+wsus_server_core_service_state: started
+wsus_server_core_service_enabled: true

--- a/roles/wsus_server_core/handlers/main.yml
+++ b/roles/wsus_server_core/handlers/main.yml
@@ -1,0 +1,10 @@
+---
+- name: Restart WSUS
+  ansible.windows.win_service:
+    name: "{{ wsus_server_core_service_name }}"
+    state: restarted
+
+- name: Restart IIS
+  ansible.windows.win_service:
+    name: "{{ wsus_server_core_iis_service_name }}"
+    state: restarted

--- a/roles/wsus_server_core/meta/main.yml
+++ b/roles/wsus_server_core/meta/main.yml
@@ -1,0 +1,18 @@
+galaxy_info:
+  author: your company
+  description: WSUS Server Core Role
+  company: your company
+  license: MIT
+  min_ansible_version: 2.9
+  platforms:
+    - name: Windows
+      versions:
+        - 2016
+        - 2019
+        - 2022
+  galaxy_tags:
+    - windows
+    - wsus
+    - update
+
+dependencies: []

--- a/roles/wsus_server_core/tasks/01_install.yml
+++ b/roles/wsus_server_core/tasks/01_install.yml
@@ -1,0 +1,13 @@
+---
+# 1. WSUSの機能コンポーネントをインストール
+- name: Install WSUS and dependencies
+  ansible.windows.win_feature:
+    name: "{{ wsus_server_core_features }}"
+    state: present
+    include_management_tools: true
+  register: wsus_feature_install
+
+# 2. WSUSの再起動
+- name: Reboot if required by WSUS installation
+  ansible.windows.win_reboot:
+  when: wsus_feature_install.reboot_required

--- a/roles/wsus_server_core/tasks/02_post_install.yml
+++ b/roles/wsus_server_core/tasks/02_post_install.yml
@@ -1,0 +1,28 @@
+---
+# 1. WSUSのコンテンツディレクトリを確認
+- name: Ensure WSUS Content Directory exists
+  ansible.windows.win_file:
+    path: "{{ wsus_server_core_content_dir }}"
+    state: directory
+
+# 2. WSUSが設定済みか確認 (WsusContentフォルダの有無)
+- name: Check if WSUS is configured
+  ansible.windows.win_stat:
+    path: "{{ wsus_server_core_content_dir }}\\WsusContent"
+  register: wsus_content
+
+# 3. WSUSの初期設定 (PostInstall)
+- name: Run WSUS PostInstall (Initialize WID and Content Dir)
+  ansible.windows.win_command: >
+    "{{ wsus_server_core_wsusutil_path }}" postinstall CONTENT_DIR="{{ wsus_server_core_content_dir }}"
+  when: not wsus_content.stat.exists
+  notify:
+    - Restart WSUS
+    - Restart IIS
+
+# 4. WSUSサービスを起動
+- name: Ensure WSUS Service is started
+  ansible.windows.win_service:
+    name: "{{ wsus_server_core_service_name }}"
+    state: "{{ wsus_server_core_service_state }}"
+    start_mode: auto

--- a/roles/wsus_server_core/tasks/03_configure_iis.yml
+++ b/roles/wsus_server_core/tasks/03_configure_iis.yml
@@ -1,0 +1,8 @@
+---
+# 3. WsusPoolのメモリ制限解除 (Private Memory Limit = 0)
+- name: Disable private memory limit for WsusPool (prevent crashing)
+  community.windows.win_iis_webapppool:
+    name: WsusPool
+    attributes:
+      recycling.periodicRestart.privateMemory: 0
+  notify: Restart WSUS

--- a/roles/wsus_server_core/tasks/04_schedule_cleanup.yml
+++ b/roles/wsus_server_core/tasks/04_schedule_cleanup.yml
@@ -1,0 +1,17 @@
+---
+# 4. 定期的なお掃除タスクのスケジュール登録
+- name: Schedule WSUS Cleanup Task
+  community.windows.win_scheduled_task:
+    name: "WSUS Monthly Cleanup"
+    description: "Run WSUS Server Cleanup Wizard automatically to remove obsolete updates and computers."
+    actions:
+      - path: powershell.exe
+        arguments: "-Command Invoke-WsusServerCleanup -CleanupObsoleteComputers -CleanupObsoleteUpdates -CompressUpdates"
+    triggers:
+      - type: monthly
+        start_boundary: '2025-12-23T02:00:00'
+        days_of_month: 1
+        at: "03:00"
+    username: SYSTEM
+    state: present
+    enabled: true

--- a/roles/wsus_server_core/tasks/main.yml
+++ b/roles/wsus_server_core/tasks/main.yml
@@ -1,0 +1,5 @@
+---
+- include_tasks: 01_install.yml
+- include_tasks: 02_post_install.yml
+- include_tasks: 03_configure_iis.yml
+- include_tasks: 04_schedule_cleanup.yml

--- a/roles/wsus_server_core/tests/README.md
+++ b/roles/wsus_server_core/tests/README.md
@@ -1,0 +1,84 @@
+# WSUS Server Core Role - Test Guide
+
+このディレクトリには、Azure 上にテスト用の Windows Server インスタンスを構築し、WSUS Role の Pester テストを実行するための環境が含まれています。
+
+## 📋 前提条件
+
+*   Terraform installed
+*   Ansible installed
+*   Azure CLI (`az login` でログイン済みであること)
+
+## 📁 ディレクトリ構成
+
+*   `azure_infra/`: Terraform コード。Azure 上に VM とネットワークリソースを作成します。
+*   `pester/`: Pester テストコード (`Wsus.Tests.ps1`)。
+*   `inventory.ini`: テスト対象のインベントリファイル。
+*   `test_pester.yml`: Pester テストを実行するための Playbook。
+
+## 🚀 テスト環境の構築 (Terraform)
+
+1.  `azure_infra` ディレクトリに移動します。
+    ```bash
+    cd azure_infra
+    ```
+
+2.  Terraform を初期化します。
+    ```bash
+    terraform init
+    ```
+
+3.  `terraform.tfvars` ファイルを作成・編集し、`admin_password` を設定します（必要な場合）。
+    ```hcl
+    admin_password = "YourStrongPassword123!"
+    ```
+
+4.  リソースを作成します。
+    ```bash
+    terraform apply
+    ```
+    *   確認プロンプトで `yes` を入力します。
+
+5.  出力された Public IP アドレスをメモします。
+    ```bash
+    # 出力例
+    public_ip_address = "20.10.10.10"
+    ```
+
+## 📝 インベントリの設定
+
+`tests/inventory.ini` を編集し、Terraform で取得した IP アドレスと、設定したパスワードを反映させます。
+
+```ini
+[wsus_servers]
+<Public_IP_Address>
+
+[wsus_servers:vars]
+ansible_user=azureuser
+ansible_password="YourStrongPassword123!"
+ansible_connection=winrm
+ansible_winrm_server_cert_validation=ignore
+ansible_winrm_transport=ntlm
+```
+
+## 🧪 テストの実行
+
+Project root または `tests` ディレクトリから以下のコマンドを実行し、Pester テストを実行します。
+
+```bash
+access ansible-playbook -i inventory.ini test_pester.yml
+```
+
+この Playbook は以下の処理を行います：
+1.  Pester モジュールのインストール
+2.  テストファイル (`Wsus.Tests.ps1`) の転送
+3.  テストの実行と結果の表示
+
+## 🧹 環境の削除
+
+テストが完了したら、Azure リソースを削除して課金を停止します。
+
+```bash
+cd azure_infra
+terraform destroy
+```
+*   確認プロンプトで `yes` を入力します。

--- a/roles/wsus_server_core/tests/azure_infra/.gitignore
+++ b/roles/wsus_server_core/tests/azure_infra/.gitignore
@@ -1,0 +1,15 @@
+# Terraform関連
+# ローカルの一時ファイル（プラグインなど）
+.terraform/
+.terraform.lock.hcl
+.terraform.tfstate.lock.info
+
+# 状態管理ファイル
+*.tfstate
+*.tfstate.backup
+
+# 変数ファイル
+*.tfvars
+
+# クラッシュログ
+crash.log

--- a/roles/wsus_server_core/tests/azure_infra/compute.tf
+++ b/roles/wsus_server_core/tests/azure_infra/compute.tf
@@ -1,0 +1,49 @@
+resource "azurerm_windows_virtual_machine" "vm" {
+  name                = "${var.prefix}-vm"
+  resource_group_name = azurerm_resource_group.rg.name
+  location            = azurerm_resource_group.rg.location
+  size                = "Standard_B2as_v2"
+
+  # Spotインスタンス設定を追加
+  priority        = "Spot"
+  eviction_policy = "Delete"
+  max_bid_price   = -1 # -1 は「価格による停止はしない（容量不足のみ停止）」の意味
+
+  admin_username = var.admin_username
+  admin_password = var.admin_password
+  network_interface_ids = [
+    azurerm_network_interface.nic.id,
+  ]
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "MicrosoftWindowsServer"
+    offer     = "WindowsServer"
+    sku       = "2025-datacenter-smalldisk-g2"
+    version   = "latest"
+  }
+
+}
+
+# WinRM設定スクリプトの自動実行
+resource "azurerm_virtual_machine_extension" "winrm_setup" {
+  name                 = "winrm-setup"
+  virtual_machine_id   = azurerm_windows_virtual_machine.vm.id
+  publisher            = "Microsoft.Compute"
+  type                 = "CustomScriptExtension"
+  type_handler_version = "1.10"
+
+  settings = <<SETTINGS
+    {
+        "fileUris": ["https://raw.githubusercontent.com/ansible/ansible-documentation/devel/examples/scripts/ConfigureRemotingForAnsible.ps1"],
+        "commandToExecute": "powershell.exe -ExecutionPolicy Unrestricted -File ConfigureRemotingForAnsible.ps1"
+    }
+SETTINGS
+
+  # VM作成後に実行されるように依存関係を明示（ID参照してるので暗黙的にも効きますが念の為）
+  depends_on = [azurerm_windows_virtual_machine.vm]
+}

--- a/roles/wsus_server_core/tests/azure_infra/main.tf
+++ b/roles/wsus_server_core/tests/azure_infra/main.tf
@@ -1,0 +1,4 @@
+resource "azurerm_resource_group" "rg" {
+  name     = "${var.prefix}-rg"
+  location = var.location
+}

--- a/roles/wsus_server_core/tests/azure_infra/network.tf
+++ b/roles/wsus_server_core/tests/azure_infra/network.tf
@@ -1,0 +1,57 @@
+resource "azurerm_virtual_network" "vnet" {
+  name                = "${var.prefix}-vnet"
+  address_space       = ["10.0.0.0/16"]
+  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
+}
+
+resource "azurerm_subnet" "subnet" {
+  name                 = "internal"
+  resource_group_name  = azurerm_resource_group.rg.name
+  virtual_network_name = azurerm_virtual_network.vnet.name
+  address_prefixes     = ["10.0.1.0/24"]
+}
+
+resource "azurerm_public_ip" "pip" {
+  name                = "${var.prefix}-pip"
+  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
+  allocation_method   = "Dynamic"
+}
+
+resource "azurerm_network_interface" "nic" {
+  name                = "${var.prefix}-nic"
+  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
+
+  ip_configuration {
+    name                          = "internal"
+    subnet_id                     = azurerm_subnet.subnet.id
+    private_ip_address_allocation = "Dynamic"
+    public_ip_address_id          = azurerm_public_ip.pip.id
+  }
+}
+
+# WinRM (5986) を許可するセキュリティグループ
+resource "azurerm_network_security_group" "nsg" {
+  name                = "${var.prefix}-nsg"
+  location            = azurerm_resource_group.rg.location
+  resource_group_name = azurerm_resource_group.rg.name
+
+  security_rule {
+    name                       = "AllowWinRM"
+    priority                   = 1001
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_port_range          = "*"
+    destination_port_range     = "5986"
+    source_address_prefix      = "*" # セキュリティ重視なら自身のIPを指定
+    destination_address_prefix = "*"
+  }
+}
+
+resource "azurerm_network_interface_security_group_association" "nsg_assoc" {
+  network_interface_id      = azurerm_network_interface.nic.id
+  network_security_group_id = azurerm_network_security_group.nsg.id
+}

--- a/roles/wsus_server_core/tests/azure_infra/outputs.tf
+++ b/roles/wsus_server_core/tests/azure_infra/outputs.tf
@@ -1,0 +1,15 @@
+output "public_ip" {
+  description = "VMのパブリックIPアドレス"
+  value       = azurerm_public_ip.pip.ip_address
+}
+
+output "username" {
+  description = "管理者ユーザー名"
+  value       = var.admin_username
+}
+
+output "password" {
+  description = "管理者パスワード"
+  value       = var.admin_password
+  sensitive   = true
+}

--- a/roles/wsus_server_core/tests/azure_infra/variables.tf
+++ b/roles/wsus_server_core/tests/azure_infra/variables.tf
@@ -1,0 +1,19 @@
+variable "prefix" {
+  description = "リソース名のプレフィックス"
+  default     = "ansible-test"
+}
+
+variable "location" {
+  description = "リソースを作成するリージョン"
+  default     = "Japan East"
+}
+
+variable "admin_username" {
+  description = "VMの管理者ユーザー名"
+  default     = "azureuser"
+}
+
+variable "admin_password" {
+  description = "VMの管理者パスワード"
+  sensitive   = true
+}

--- a/roles/wsus_server_core/tests/azure_infra/versions.tf
+++ b/roles/wsus_server_core/tests/azure_infra/versions.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 3.0"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+}

--- a/roles/wsus_server_core/tests/pester/Wsus.Tests.ps1
+++ b/roles/wsus_server_core/tests/pester/Wsus.Tests.ps1
@@ -1,0 +1,28 @@
+﻿Describe "WSUS Installation" {
+
+    Context "Services" {
+        It "WsusService service should be running" {
+            $service = Get-Service -Name "WsusService" -ErrorAction SilentlyContinue
+            $service.Status | Should -Be "Running"
+        }
+        
+        It "Service startup type should be Automatic" {
+            $service = Get-Service -Name "WsusService" -ErrorAction SilentlyContinue
+            $service.StartType | Should -Be "Automatic"
+        }
+    }
+
+    Context "Files" {
+        
+        It "Installation directory should exist" {
+            $installPath = "C:\Program Files\Update Services"
+            Test-Path $installPath | Should -Be $true
+        }
+    }
+    
+    Context "Registry" {
+        It "Specified registry key should exist" {
+            Test-Path "HKLM:\SOFTWARE\Microsoft\Update Services\Server" | Should -Be $true
+        }
+    }
+}

--- a/roles/wsus_server_core/tests/test.yml
+++ b/roles/wsus_server_core/tests/test.yml
@@ -1,0 +1,20 @@
+---
+- name: Test Role
+  hosts: windows
+  gather_facts: false  # テスト高速化のため全体ではOFF
+
+  tasks:
+    # 1. 接続確認
+    - name: Verify connection
+      ansible.windows.win_ping:
+
+    # 2. 作成したRoleを実行 (インストール)
+    - name: Run wsus_server_core role
+      import_role:
+        name: ../../wsus_server_core
+
+    # 3. 検証
+    - name: Verify WSUS installation
+      ansible.windows.win_service:
+        name: WsusService
+        state: started

--- a/roles/wsus_server_core/tests/test_pester.yml
+++ b/roles/wsus_server_core/tests/test_pester.yml
@@ -1,0 +1,46 @@
+- name: Test with Pester
+  hosts: windows
+  gather_facts: no
+  vars:
+    pester_test_file: "./pester/Wsus.Tests.ps1"
+    pester_test_file_dest: 'C:\Temp\Wsus.Tests.ps1'
+
+  tasks:
+    # 1. Pesterのインストール
+    - name: Install Pester module
+      community.windows.win_psmodule:
+        name: Pester
+        state: latest
+        allow_clobber: yes
+        skip_publisher_check: yes
+
+    # 2. テストファイルをWindowsへ転送
+    - name: Copy Pester test file
+      ansible.windows.win_copy:
+        src: "{{ pester_test_file }}"
+        dest: "{{ pester_test_file_dest }}"
+
+    # 3. Pesterを実行
+    - name: Run Pester Tests
+      ansible.windows.win_shell: |
+        # 出力をUTF-8に設定
+        $OutputEncoding = [System.Text.Encoding]::UTF8
+        [Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+
+        # Pesterを実行し、失敗があれば終了コード1を返す設定
+        Import-Module Pester -MinimumVersion 5.0 -Force
+
+        $config = New-PesterConfiguration
+        $config.Run.Path = "{{ pester_test_file_dest }}"
+        $config.Run.Exit = $true
+        $config.Output.Verbosity = 'Detailed'
+
+        Invoke-Pester -Configuration $config
+      register: pester_result
+      # テスト失敗時にPlaybookも失敗させる
+      failed_when: pester_result.rc != 0
+
+    # 4. 結果の表示 (デバッグ用)
+    - name: Show Pester Output
+      debug:
+        var: pester_result.stdout_lines

--- a/roles/wsus_server_core/vars/main.yml
+++ b/roles/wsus_server_core/vars/main.yml
@@ -1,0 +1,7 @@
+---
+# Service Names
+wsus_server_core_service_name: WsusService
+wsus_server_core_iis_service_name: W3SVC
+
+# Executable paths
+wsus_server_core_wsusutil_path: 'C:\Program Files\Update Services\Tools\wsusutil.exe'


### PR DESCRIPTION
WSUSサーバーコアのAnsibleロールを新規追加し、インストール、設定、定期クリーンアップタスクを実装。Azure上にテスト用インフラを構築するためのTerraformコードと、Pesterテストを実行するための設定を追加。READMEを更新し、テスト手順を明確化。

This PR fixes #18